### PR TITLE
fix flaky test GsonParserTest

### DIFF
--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/GsonParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/GsonParserTest.java
@@ -12,6 +12,7 @@ import cz.habarta.typescript.generator.TypeScriptGenerator;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import java.util.stream.Collectors;
 
 @SuppressWarnings("unused")
 public class GsonParserTest {
@@ -37,7 +38,7 @@ public class GsonParserTest {
         final BeanModel beanModel = model.getBeans().get(0);
         Assert.assertEquals("DummyBean", beanModel.getOrigin().getSimpleName());
         Assert.assertTrue(beanModel.getProperties().size() > 0);
-        Assert.assertEquals("firstProperty", beanModel.getProperties().get(0).getName());
+        Assert.assertTrue(beanModel.getProperties().stream().map( i -> i.getName()).collect(Collectors.toList()).contains("firstProperty"));
     }
 
     @Test


### PR DESCRIPTION
Fixed flaky test GsonParserTest.
The original test supposed the results of getProperties() would be ordered which may not be true at all times.